### PR TITLE
⬆ Allow any node engine greater than 0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "./index.js",
   "bin": "./index.js",
   "engines": {
-    "node": "~0.6.2"
+    "node": ">=0.6.2"
   },
   "scripts" : {
     "test" : "node test/tests.js"


### PR DESCRIPTION
This change will remove warnings during `npm install`.
i.e.
```
npm WARN engine jcsv@0.0.3: wanted: {"node":"~0.6.2"} (current: {"node":"4.6.2","npm":"2.15.11"})
```

It will also make the module usable via yarn, which is much stricter
about the engine

```
error jcsv@0.0.3: The engine "node" is incompatible with this module. Expected version "~0.6.2".
error Found incompatible module
```

Test results with some different versions of node.js
```
$ nvm use v4.6
Now using node v4.6.2 (npm v2.15.11)
$ npm test

> jcsv@0.0.3 test /home/dmartin/work/jcsv
> node test/tests.js

a,b,c,d,e,f;
1,2,,,,;
3,4,5,,,;
6,7,8,true,"string",[object Object];

Tests passed ok!


$ nvm use v6
Now using node v6.10.2 (npm v3.10.10)
$ npm test

> jcsv@0.0.3 test /home/dmartin/work/jcsv
> node test/tests.js

a,b,c,d,e,f;
1,2,,,,;
3,4,5,,,;
6,7,8,true,"string",[object Object];

Tests passed ok!


$ nvm use 0.10
Now using node v0.10.41 (npm v2.14.14)
$ npm test

> jcsv@0.0.3 test /home/dmartin/work/jcsv
> node test/tests.js

a,b,c,d,e,f;
1,2,,,,;
3,4,5,,,;
6,7,8,true,"string",[object Object];

Tests passed ok!
```